### PR TITLE
Fix Lambda Timeout Bug and DB Connection Lifecycle

### DIFF
--- a/backend/graphql/resolvers/mutation.js
+++ b/backend/graphql/resolvers/mutation.js
@@ -4,70 +4,138 @@
 const getSubscriptionController = require('../../controllers/subscriptionsController');
 const getValidator = require('./validators');
 
-module.exports = (logger, dbClient, twilioClient) => {
-  const subscriptionController = getSubscriptionController(logger, dbClient, twilioClient);
+module.exports = (logger) => {
+  const subscriptionController = getSubscriptionController(logger);
   const validator = getValidator(logger);
 
   const module = {};
 
-  module.createMeeting = async (args) => {
+  module.createMeeting = async (dbClient, args) => {
     validator.validateCreateMeeting(args);
-    let res = await dbClient.createMeeting(
-      args.meeting_type, args.meeting_start_timestamp, args.virtual_meeting_url, args.status,
-    );
+
+    let res;
+    try {
+      res = await dbClient.createMeeting(
+        args.meeting_type, args.meeting_start_timestamp, args.virtual_meeting_url, args.status,
+      );
+    } catch (e) {
+      logger.error(`createMeeting resolver error - dbClient.createMeeting: ${e}`);
+      throw e;
+    }
 
     if (res != null) {
       const newId = res.rows[0].id;
-      res = await dbClient.getMeeting(newId);
+      try {
+        res = await dbClient.getMeeting(newId);
+      } catch (e) {
+        logger.error(`createMeeting resolver error - dbClient.getMeeting: ${e}`);
+        throw e;
+      }
     } else {
+      logger.error('createMeeting resolver error - dbClient.createMeeting response is null');
       throw Error('Internal Error');
     }
 
     if (res != null) {
       return res.rows[0];
     }
+    logger.error('createMeeting resolver error - dbClient.getMeeting response is null');
     throw Error('Internal Error');
   };
 
-  module.createMeetingItem = async (args) => {
+  module.createMeetingItem = async (dbClient, args) => {
     validator.validateCreateMeetingItem(args);
-    let res = await dbClient.createMeetingItem(
-      args.meeting_id, args.order_number, args.item_start_timestamp, args.item_end_timestamp,
-      args.status, args.content_categories, args.description_loc_key, args.title_loc_key,
-    );
+
+    let res;
+    try {
+      res = await dbClient.createMeetingItem(
+        args.meeting_id, args.order_number, args.item_start_timestamp, args.item_end_timestamp,
+        args.status, args.content_categories, args.description_loc_key, args.title_loc_key,
+      );
+    } catch (e) {
+      logger.error(`createMeetingItem resolver error - dbClient.createMeetingItem: ${e}`);
+      throw e;
+    }
     const newId = res.rows[0].id;
-    res = await dbClient.getMeetingItem(newId);
+
+    try {
+      res = await dbClient.getMeetingItem(newId);
+    } catch (e) {
+      logger.error(`createMeetingItem resolver error - dbClient.getMeetingItem: ${e}`);
+      throw e;
+    }
     return res.rows[0];
   };
 
-  module.createSubscription = async (args) => {
+  module.createSubscription = async (dbClient, args) => {
     validator.validateCreateSubscription(args);
-    let res = await dbClient.createSubscription(
-      args.phone_number, args.email_address, args.meeting_item_id, args.meeting_id,
-    );
+
+    let res;
+    try {
+      res = await dbClient.createSubscription(
+        args.phone_number, args.email_address, args.meeting_item_id, args.meeting_id,
+      );
+    } catch (e) {
+      logger.error(`createSubscription resolver error - dbClient.createSubscription: ${e}`);
+      throw e;
+    }
     const newId = res.rows[0].id;
-    res = await dbClient.getSubscription(newId);
+
+    try {
+      res = await dbClient.getSubscription(newId);
+    } catch (e) {
+      logger.error(`createSubscription resolver error - dbClient.getSubscription: ${e}`);
+      throw e;
+    }
     return res.rows[0];
   };
 
-  module.updateMeetingItem = async (args) => {
+  module.updateMeetingItem = async (dbClient, args) => {
     validator.validateUpdateMeetingItem(args);
-    let res = await dbClient.updateMeetingItem(
-      args.id, args.order_number, args.status, args.item_start_timestamp,
-      args.item_end_timestamp, args.content_categories, args.description_loc_key,
-      args.title_loc_key,
-    );
-    res = await dbClient.getMeetingItem(args.id);
+
+    let res;
+    try {
+      res = await dbClient.updateMeetingItem(
+        args.id, args.order_number, args.status, args.item_start_timestamp,
+        args.item_end_timestamp, args.content_categories, args.description_loc_key,
+        args.title_loc_key,
+      );
+    } catch (e) {
+      logger.error(`updateMeetingItem resolver error - dbClient.updateMeetingItem: ${e}`);
+      throw e;
+    }
+
+    // TODO: Check if update was successful
+
+    try {
+      res = await dbClient.getMeetingItem(args.id);
+    } catch (e) {
+      logger.error(`updateMeetingItem resolver error - dbClient.getMeetingItem: ${e}`);
+      throw e;
+    }
     const meetingItem = res.rows[0];
 
     // TODO: Validation required: only send notifications if update was successful
     switch (args.status) {
       case 'COMPLETED':
-        subscriptionController.notifyItemSubscribers(args.id, 'ITEM(S) COMPLETED: ');
+        try {
+          await subscriptionController.notifyItemSubscribers(dbClient, args.id, 'ITEM(S) COMPLETED: ');
+        } catch (e) {
+          logger.error(`Error notifying item subscribers: ${e}`);
+        }
         break;
+
       case 'IN PROGRESS':
-        subscriptionController.notifyItemSubscribers(args.id, 'ITEM(S) IN PROGRESS: ');
-        subscriptionController.notifyNextItemSubscribers(meetingItem, 'YOUR ITEM(S) IS/ARE UP NEXT: ');
+        try {
+          await subscriptionController.notifyItemSubscribers(dbClient, args.id, 'ITEM(S) IN PROGRESS: ');
+        } catch (e) {
+          logger.error(`Error notifying item subscribers: ${e}`);
+        }
+        try {
+          await subscriptionController.notifyNextItemSubscribers(dbClient, meetingItem, 'YOUR ITEM(S) IS/ARE UP NEXT: ');
+        } catch (e) {
+          logger.error(`Error notifying "next" item subscribers: ${e}`);
+        }
         break;
       default:
           // TODO: This state should be impossible, handle as an error
@@ -76,26 +144,48 @@ module.exports = (logger, dbClient, twilioClient) => {
     return meetingItem;
   };
 
-  module.updateMeeting = async (args) => {
+  module.updateMeeting = async (dbClient, args) => {
     validator.validateUpdateMeeting(args);
-    let res = await dbClient.updateMeeting(
-      args.id, args.status, args.meeting_type, args.virtual_meeting_url,
-      args.meeting_start_timestamp, args.meeting_end_timestamp,
-    );
+
+    let res;
+    try {
+      res = await dbClient.updateMeeting(
+        args.id, args.status, args.meeting_type, args.virtual_meeting_url,
+        args.meeting_start_timestamp, args.meeting_end_timestamp,
+      );
+    } catch (e) {
+      logger.error(`updateMeeting resolver error - dbClient.updateMeeting: ${e}`);
+      throw e;
+    }
 
     // TODO: Validation required: only send notifications if update was successful
     switch (args.status) {
       case 'COMPLETED':
-        subscriptionController.notifyMeetingSubscribers(args.id, 'MEETING COMPLETE: ');
+        try {
+          await subscriptionController.notifyMeetingSubscribers(dbClient, args.id, 'MEETING COMPLETE: ');
+        } catch (e) {
+          logger.error(`updateMeeting resolver error - subscriptionController.notifyMeetingSubscribers: ${e}`);
+          throw e;
+        }
         break;
       case 'IN PROGRESS':
-        subscriptionController.notifyMeetingSubscribers(args.id, 'MEETING IN PROGRESS: ');
+        try {
+          await subscriptionController.notifyMeetingSubscribers(dbClient, args.id, 'MEETING IN PROGRESS: ');
+        } catch (e) {
+          logger.error(`updateMeeting resolver error - subscriptionController.notifyMeetingSubscribers: ${e}`);
+          throw e;
+        }
         break;
       default:
           // TODO: This state should be impossible, handle as an error
     }
 
-    res = await dbClient.getMeeting(args.id);
+    try {
+      res = await dbClient.getMeeting(args.id);
+    } catch (e) {
+      logger.error(`updateMeeting resolver error - dbClient.getMeeting: ${e}`);
+      throw e;
+    }
     return res.rows[0];
   };
 

--- a/backend/graphql/resolvers/query.js
+++ b/backend/graphql/resolvers/query.js
@@ -1,32 +1,69 @@
 // TODO: error handling and data validation is required here
 // ex: verify that ids exist, undefined values should be passed as empty strings, etc...
 
-module.exports = (logger, dbClient) => {
+module.exports = (logger) => {
   const module = {};
 
-  const getAllMeetings = async () => {
-    const res = await dbClient.getAllMeetings();
+  const getAllMeetings = async (dbClient) => {
+    let res;
+    try {
+      res = await dbClient.getAllMeetings();
+    } catch (e) {
+      logger.error(`getAllMeetings resolver error - dbClient.getAllMeetings: ${e}`);
+      throw e;
+    }
     return res.rows;
   };
 
-  const getMeeting = async (id) => {
-    const res = await dbClient.getMeeting(id);
+  const getMeeting = async (dbClient, id) => {
+    let res;
+    try {
+      res = await dbClient.getMeeting(id);
+    } catch (e) {
+      logger.error(`getMeeting resolver error - dbClient.getMeeting: ${e}`);
+      throw e;
+    }
     return res.rows[0];
   };
 
-  const getAllMeetingItems = async () => {
-    const res = await dbClient.getAllMeetingItems();
+  const getAllMeetingItems = async (dbClient) => {
+    let res;
+    try {
+      res = await dbClient.getAllMeetingItems();
+    } catch (e) {
+      logger.error(`getAllMeetingItems resolver error - dbClient.getAllMeetingItems: ${e}`);
+      throw e;
+    }
     return res.rows;
   };
 
-  const getMeetingItem = async (id) => {
-    const res = await dbClient.getMeetingItem(id);
+  const getMeetingItem = async (dbClient, id) => {
+    let res;
+    try {
+      res = await dbClient.getMeetingItem(id);
+    } catch (e) {
+      logger.error(`getMeetingItem resolver error - dbClient.getMeetingItem: ${e}`);
+      throw e;
+    }
     return res.rows[0];
   };
 
-  const getMeetingWithItems = async (id) => {
-    const meetingObj = getMeeting(id);
-    const res = await dbClient.getMeetingItemsByMeetingID(id);
+  const getMeetingWithItems = async (dbClient, id) => {
+    let meetingObj;
+    try {
+      meetingObj = await getMeeting(dbClient, id);
+    } catch (e) {
+      logger.error(`getMeetingWithItems resolver error - getMeeting: ${e}`);
+      throw e;
+    }
+
+    let res;
+    try {
+      res = await dbClient.getMeetingItemsByMeetingID(id);
+    } catch (e) {
+      logger.error(`getMeetingWithItems resolver error - dbClient.getMeetingItemsByMeetingID: ${e}`);
+      throw e;
+    }
     const associatedItems = res.rows;
 
     return {
@@ -35,29 +72,55 @@ module.exports = (logger, dbClient) => {
     };
   };
 
-  const getAllMeetingsWithItems = async () => {
+  const getAllMeetingsWithItems = async (dbClient) => {
+    let res;
+    try {
+      res = await dbClient.getAllMeetingIDs();
+    } catch (e) {
+      logger.error(`getAllMeetingsWithItems resolver error - dbClient.getAllMeetingIDs: ${e}`);
+      throw e;
+    }
+
     const meetingIDs = [];
-    const res = await dbClient.getAllMeetingIDs();
     res.rows.forEach((row) => {
       meetingIDs.push(row.id);
     });
 
     const allMeetingsWithItems = [];
-    meetingIDs.forEach((id) => {
-      const meetingWithItems = getMeetingWithItems(id);
-      allMeetingsWithItems.push(meetingWithItems);
-    });
+    try {
+      for (let i = 0; i < meetingIDs.length; i += 1) {
+        const id = meetingIDs[i];
+        // eslint-disable-next-line no-await-in-loop
+        const meetingWithItems = await getMeetingWithItems(dbClient, id);
+        allMeetingsWithItems.push(meetingWithItems);
+      }
+    } catch (e) {
+      logger.error(`getAllMeetingsWithItems resolver error - getMeetingWithItems: ${e}`);
+      throw e;
+    }
 
     return allMeetingsWithItems;
   };
 
-  const getSubscription = async (id) => {
-    const res = await dbClient.getSubscription(id);
+  const getSubscription = async (dbClient, id) => {
+    let res;
+    try {
+      res = await dbClient.getSubscription(id);
+    } catch (e) {
+      logger.error(`getSubscription resolver error - dbClient.getSubscription: ${e}`);
+      throw e;
+    }
     return res.rows[0];
   };
 
-  const getAllSubscriptions = async () => {
-    const res = await dbClient.getAllSubscriptions();
+  const getAllSubscriptions = async (dbClient) => {
+    let res;
+    try {
+      res = await dbClient.getAllSubscriptions();
+    } catch (e) {
+      logger.error(`getAllSubscriptions resolver error - dbClient.getAllSubscriptions: ${e}`);
+      throw e;
+    }
     return res.rows;
   };
 

--- a/backend/graphql/resolvers/validators.js
+++ b/backend/graphql/resolvers/validators.js
@@ -106,8 +106,6 @@ module.exports = (logger) => {
   };
 
   const validateTwilioSafePhoneNumber = (phoneNumber, fieldName, context) => {
-    logger.error(phoneNumber.charAt(0));
-
     if (!isNumericString(phoneNumber)) {
       const msg = `Invalid "${fieldName}" field value. Number not numeric: ${phoneNumber}`;
       throwUserInputError(msg, context);

--- a/backend/handler.js
+++ b/backend/handler.js
@@ -2,12 +2,10 @@ require('dotenv').config();
 
 const PORT = process.env.PORT || 3000;
 const logger = require('./utilities/logger');
-const dbClient = require('./db/dbClient')(logger);
-const twilioClient = require('./twilio/twilioClient')(logger);
-
-const server = require('./graphql/apolloServer')(dbClient, twilioClient, logger);
+const server = require('./graphql/apolloServer')(logger);
 
 if (process.env.IS_LAMBDA) {
+  logger.info('Exporting lambda handler');
   exports.graphqlHandler = server.createHandler({
     cors: {
       origin: '*',
@@ -17,6 +15,6 @@ if (process.env.IS_LAMBDA) {
   });
 } else {
   server.listen(PORT).then(({ url }) => {
-    logger.info(`🚀 Server ready at ${url}`);
+    logger.info(`🚀 Server ready for local dev at: ${url}`);
   });
 }


### PR DESCRIPTION
The handler was set up like a monolithic express server. This causes issues in Lambda since the API handler isn't a long living server anymore.

We were having intermittent API errors where the lambda was timing out before the GraphQL resolvers received requests.

The timeouts were being caused by the use of a single DB connection that was initialized in the handler and passed downstream before the server exposed anything. If the db connection wasn't established immediately the lambda wasn't able to receive requests and didn't expose the GraphQL playground.

Additionally, db connection lifecycles weren't being handled with consideration to Lambda's environment. Connections weren't being created and closed for every request.

This PR addresses both of these problems.
