### PR TITLE
imported fonts used on the mocks

### DIFF
--- a/frontend/src/utils/_fonts.scss
+++ b/frontend/src/utils/_fonts.scss
@@ -1,0 +1,7 @@
+// Poppins Regular 400
+@import url('https://fonts.googleapis.com/css2?family=Poppins&display=swap');
+// font-family: 'Poppins', sans-serif;
+
+// Poppins Semi-bold 600
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@600&display=swap');
+// font-family: 'Poppins', sans-serif;


### PR DESCRIPTION
Poppins font family:

- Regular (400)
- Semi-bold (600)