### PR TITLE
Implement Nested Meeting Items

### DIFF
--- a/backend/docker/dev/init.sql
+++ b/backend/docker/dev/init.sql
@@ -15,6 +15,7 @@ CREATE TABLE meeting (
 CREATE TABLE meeting_item (
     id SERIAL NOT NULL PRIMARY KEY,
     meeting_id INT NOT NULL,
+    parent_meeting_id INT,
     order_number INT,
     created_timestamp TIMESTAMP NOT NULL,
     updated_timestamp TIMESTAMP NOT NULL,
@@ -44,20 +45,37 @@ CREATE TABLE admin (
     email_address VARCHAR(255)
 );
 
+-- The meeting of all meetings
 INSERT INTO meeting(meeting_type, status, created_timestamp, updated_timestamp, meeting_start_timestamp, meeting_end_timestamp, virtual_meeting_url)
 VALUES ('test', 'PENDING', current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'google.com');
 
 
-INSERT INTO meeting_item(meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
-VALUES (1, 1, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Description loc key', 'Title loc key');
+-- This is a item, with two nested items
+INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+VALUES (1, NULL, 1, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Example number 1', 'Meeting Item with 2 nested items');
 
-INSERT INTO meeting_item(meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
-VALUES (1, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Description loc key', 'Title loc key');
+INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+VALUES (1, 1, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Look, nested items', 'Nested item');
 
-INSERT INTO meeting_item(meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
-VALUES (1, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Description loc key', 'Title loc key');
+INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+VALUES (1, 2, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Call me a bird home...lol', 'Super nested item');
+
+-- This is a item, with a single nested item
+INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+VALUES (1, NULL, 1, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Example number 2', 'Meeting Item with One Nested Item');
+
+INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+VALUES (1, 4, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Another nested item', 'Nested item');
+
+-- These items aren't nested
+INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+VALUES (1, NULL, 1, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Example number 3', 'Not nested');
+
+INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+VALUES (1, NULL, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'blah blah blah', 'Also not nested');
 
 
+-- Subscriptions
 INSERT INTO subscription(meeting_item_id, meeting_id, created_timestamp, updated_timestamp, phone_number, email_address)
 VALUES (1, 1, current_timestamp, current_timestamp, '12345678901', 'fake@faker.gov');
 

--- a/backend/docker/dev/init.sql
+++ b/backend/docker/dev/init.sql
@@ -15,7 +15,7 @@ CREATE TABLE meeting (
 CREATE TABLE meeting_item (
     id SERIAL NOT NULL PRIMARY KEY,
     meeting_id INT NOT NULL,
-    parent_meeting_id INT,
+    parent_meeting_item_id INT,
     order_number INT,
     created_timestamp TIMESTAMP NOT NULL,
     updated_timestamp TIMESTAMP NOT NULL,
@@ -51,27 +51,27 @@ VALUES ('test', 'PENDING', current_timestamp, current_timestamp, current_timesta
 
 
 -- This is a item, with two nested items
-INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+INSERT INTO meeting_item(meeting_id, parent_meeting_item_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
 VALUES (1, NULL, 1, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Example number 1', 'Meeting Item with 2 nested items');
 
-INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+INSERT INTO meeting_item(meeting_id, parent_meeting_item_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
 VALUES (1, 1, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Look, nested items', 'Nested item');
 
-INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+INSERT INTO meeting_item(meeting_id, parent_meeting_item_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
 VALUES (1, 2, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Call me a bird home...lol', 'Super nested item');
 
 -- This is a item, with a single nested item
-INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+INSERT INTO meeting_item(meeting_id, parent_meeting_item_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
 VALUES (1, NULL, 1, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Example number 2', 'Meeting Item with One Nested Item');
 
-INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+INSERT INTO meeting_item(meeting_id, parent_meeting_item_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
 VALUES (1, 4, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Another nested item', 'Nested item');
 
 -- These items aren't nested
-INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+INSERT INTO meeting_item(meeting_id, parent_meeting_item_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
 VALUES (1, NULL, 1, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'Example number 3', 'Not nested');
 
-INSERT INTO meeting_item(meeting_id, parent_meeting_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
+INSERT INTO meeting_item(meeting_id, parent_meeting_item_id, order_number, created_timestamp, updated_timestamp, item_start_timestamp, item_end_timestamp, status, content_categories, description_loc_key, title_loc_key)
 VALUES (1, NULL, 2, current_timestamp, current_timestamp, current_timestamp, current_timestamp, 'PENDING', '[]', 'blah blah blah', 'Also not nested');
 
 

--- a/backend/graphql/apolloServer.js
+++ b/backend/graphql/apolloServer.js
@@ -66,6 +66,7 @@ module.exports = (logger) => {
     type meeting_item {
         id: Int
         meeting_id: Int
+        parent_meeting_id: Int
         order_number: Int
         status: String
         created_timestamp: String

--- a/backend/graphql/apolloServer.js
+++ b/backend/graphql/apolloServer.js
@@ -66,7 +66,7 @@ module.exports = (logger) => {
     type meeting_item {
         id: Int
         meeting_id: Int
-        parent_meeting_id: Int
+        parent_meeting_item_id: Int
         order_number: Int
         status: String
         created_timestamp: String


### PR DESCRIPTION
This PR allows the nesting of meeting items. Additionally, I've included modifications to our mock data in order to showcase different levels of nesting.

The nesting is accomplished by having items simply reference separate items as a "parent". This facilitates variable amounts of nesting capabilities.

This PR address two issues:
- #68 
- #70 