### PR TITLE
Adds the ability to bring up the two required services for backend with a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,50 @@ The City of San Jose is interested in this service, but this is a project that c
 *   [List of TODO items](https://github.com/codeforsanjose/gov-agenda-notifier/projects/2)
 
 # Local Development
-## To Begin Work on the Frontend / Serve Frontend
+
+There are two ways to setup for local developemnt, with docker-compose (option 1) or directly (option 2).
+
+## Option 1
+
+When running with docker-compose, a separate persistent volume is created for PostgreSQL. Also, changes made from your local text editor is synced to the respective containers for auto restart.
+
+1. Go to the issues page to find something to work on:
+   - https://github.com/codeforsanjose/gov-agenda-notifier/issues
+1. Install Docker: https://www.docker.com/products/docker-desktop
+1. Create a `.env` file in the `/backend/graphql_api/lambda` directory
+1. Make sure the file includes these keys:
+
+   ```
+   NODE_ENV=development
+
+   PGHOST=gov-agenda-notifier_backend_pg_1
+   PGUSER=docker
+   PGPASSWORD=docker
+   PGDATABASE=devdb
+   PGPORT=5432
+
+   TWILIO_ACCOUNT_SID=AC-THIS-IS-TOP-SECRET-AND-NEEDS-TO-START-WITH-AC
+   TWILIO_AUTH_TOKEN=THIS-IS-TOP-SECRET
+   TWILIO_PHONE_NUMBER=THIS-IS-TOP-SECRET
+   ```
+
+   - This file is NOT to be included in version control. We don't want secret keys publicly accessible.
+   - Message Trace Ohrt on Slack if you need secret keys
+
+1. Run docker-compose command to bring up the apps:
+   ```bash
+   docker-compose -p gov-agenda-notifier up --build
+   ```
+1. View the GraphQL API playground at http://localhost:3000/graphql
+1. View the app at http://localhost:3001
+1. Run command to remove (most) of build artifacts:
+   ```bash
+   docker-compose -p govt-agenda-notifier down --remove-orphans
+   ```
+
+## Option 2
+
+### To Begin Work on the Frontend / Serve Frontend
 1. Go to the issues page to find something to work on:
     * https://github.com/codeforsanjose/gov-agenda-notifier/issues
 2.  Install [Node.js and npm](https://www.npmjs.com/get-npm)
@@ -59,13 +102,13 @@ Frontend specific development doesn't require these steps. Setting up the DB is 
 1. Visit the issues page to find something to work on:
     * https://github.com/codeforsanjose/gov-agenda-notifier/issues
 2.  Initialize the local DB
-    *   This step requires the `make` utility. 
+    *   This step requires the `make` utility.
         *   Additional configuration for this is required on [Windows](https://vispud.blogspot.com/2019/02/how-to-run-makefile-in-windows.html)
     1.  Install [Docker](https://www.docker.com/products/docker-desktop)
     2.  Create the Docker image for the local DB
         * This only needs to be done once unless modifcations have been made to `/backend/docker_for_local_dev_db/init.sql`. See notes below.
         1.  Navigate to `/backend/docker_for_local_dev_db`
-        2.  Run command: 
+        2.  Run command:
             ```bash
             make image
             ```
@@ -81,11 +124,11 @@ Frontend specific development doesn't require these steps. Setting up the DB is 
             ```
             NODE_ENV=development
 
-            PGHOST=127.0.0.1 
-            PGUSER=docker 
-            PGPASSWORD=docker 
-            PGDATABASE=devdb 
-            PGPORT=8888 
+            PGHOST=127.0.0.1
+            PGUSER=docker
+            PGPASSWORD=docker
+            PGDATABASE=devdb
+            PGPORT=8888
 
             TWILIO_ACCOUNT_SID=AC-THIS-IS-TOP-SECRET-AND-NEEDS-TO-START-WITH-AC
             TWILIO_AUTH_TOKEN=THIS-IS-TOP-SECRET
@@ -101,7 +144,7 @@ Frontend specific development doesn't require these steps. Setting up the DB is 
             ```
     3. Start server:
         1. Navigate to the `/backend/graphql_api/lambda` directory
-        2. Run command: 
+        2. Run command:
             ```bash
             npm start
             ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+version: "3"
+services:
+  backend_graphql:
+    image: "node:14"
+    entrypoint:
+      - "sh"
+      - "-c"
+      - "npm install && npm start"
+    working_dir: "/usr/src/app"
+    ports:
+      - "3000:3000"
+    volumes:
+      - "./backend/graphql_api/lambda:/usr/src/app"
+      # Don't sync the node_modules directory back to the client.
+      - "/usr/src/app/node_modules"
+    depends_on:
+      - backend_pg
+      - frontend
+  backend_pg:
+    build: "./backend/docker_for_local_dev_db"
+    # this is for debugging; graphql connects to PG via internal docker network
+    ports:
+      - "5431:5432"
+    volumes:
+      - ./backend/docker_for_local_dev_db/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - postgres-data:/var/lib/postgresql/data
+  frontend:
+    # node-sass 4* needs node version 14
+    image: "node:14"
+    entrypoint:
+      - "sh"
+      - "-c"
+      - "npm install && npm start"
+    working_dir: "/usr/src/app"
+    ports:
+      - "3001:3000"
+    volumes:
+      - "./frontend:/usr/src/app"
+      # Don't sync the node_modules directory back to the client.
+      - "/usr/src/app/node_modules"
+    stdin_open: true
+volumes:
+  postgres-data:


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)

`docker-compose -p gov-agenda-notifier up --remove-orphans` will bring up the frontend react app, backend graphql app and backend pg database.

Graphql starts on port 3000, React app starts on port 3001 and postgres starts on port 5431.

Both the graphql and react app source dirs are mounted as volumes on respective containers. Any changes made to those source directories restarts the respective servers. (I haven't done research into the efficiency of this, from what I can tell it's quite fast.)

`docker-compose -p gov-agenda-notifier up down --remove-orphans` will remove the build artifacts except the volume.

PG data is stored in a volume that's not tied to the container so it's accessible across restarts and compose up/down. You can remove it with `docker-compose down --remove-orphans` will remove the build artifacts except for the volume. If you make changes to `backend/docker_for_local_dev_db/init.sql` you need to remove the volume and run `docker-compose up...`.

- Describe why these changes are being made
It's important for any app to make onboarding of new developers simple, especially so for an open-source app. It took me a while to figure out how to start everything due to my inexperience with Node environments. Having a single command would have saved me some time.

- List the use cases and edge cases relevant to this PR
New developer onboarding will take just a single step if they have docker installed.

- Describe how errors will be handled. How will we know if this code breaks in production
This won't affect production.

- Describe any external libraries/dependencies added or removed in this PR
No new dependency, docker was already a dev requirement.

- Describe any security risks are there regarding this change
None.

- Describe how you tested these changes
1. Ran `docker-compose up --build --remove-orphans` from root.
2. Went to `localhost:3000` in browser and ran `{ getAllMeetings { id } }` in the input box.
3. Made changes to `backend/graphql_api/lambda/handler.js` and saw the container was restarted.
4. Made changes to `frontend/src/components/Header/Header.jsx` and saw the changes were reflected on `localhost:3001`.

- Link to relevant external documentation
<!--- Add your answer here -->
<!--- Example: API docs, architecture diagrams, MDN docs -->


--------------------------
### :clipboard: Mandatory Checklist

- [ ] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [ ] Have you discussed these changes with the project leader(s)?
- [x] Do all variable and function names communicate what they do?
- [ ] Were all the changes commented and / or documented?
- [x] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [x] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [x] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->


#### After
<img width="1440" alt="Screen Shot 2021-01-12 at 10 45 04 PM" src="https://user-images.githubusercontent.com/164864/104415992-d88ae980-5527-11eb-8679-e6b1a13a0b62.png">

<img width="1440" alt="Screen Shot 2021-01-12 at 10 31 15 PM" src="https://user-images.githubusercontent.com/164864/104414931-e7709c80-5525-11eb-8432-e1be357c1732.png">



--------------------------
### :blue_book: Glossary
- PR = Pull Request
