### PR TITLE
Send email in same flow as text message when meeting starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ When running with docker-compose, a separate persistent volume is created for Po
    TWILIO_ACCOUNT_SID=AC-THIS-IS-TOP-SECRET-AND-NEEDS-TO-START-WITH-AC
    TWILIO_AUTH_TOKEN=THIS-IS-TOP-SECRET
    TWILIO_PHONE_NUMBER=THIS-IS-TOP-SECRET
+   SEND_TEXT=false
+
+   AWS_ACCESS_KEY_ID=
+   AWS_SECRET_ACCESS_KEY=
+   AWS_DEFAULT_REGION=
+   FROM_ADDRESS=
+   SEND_EMAIL=false
    ```
 
    - This file is NOT to be included in version control. We don't want secret keys publicly accessible.
@@ -133,6 +140,13 @@ Frontend specific development doesn't require these steps. Setting up the DB is 
             TWILIO_ACCOUNT_SID=AC-THIS-IS-TOP-SECRET-AND-NEEDS-TO-START-WITH-AC
             TWILIO_AUTH_TOKEN=THIS-IS-TOP-SECRET
             TWILIO_PHONE_NUMBER=THIS-IS-TOP-SECRET
+            SEND_TEXT=false
+
+            AWS_ACCESS_KEY_ID=
+            AWS_SECRET_ACCESS_KEY=
+            AWS_DEFAULT_REGION=
+            FROM_ADDRESS=
+            SEND_EMAIL=false
             ```
             *   This file is NOT to be included in version control. We don't want secret keys publicly accessible.
             *   Message Trace Ohrt on Slack if you need secret keys

--- a/backend/graphql_api/lambda/package-lock.json
+++ b/backend/graphql_api/lambda/package-lock.json
@@ -852,6 +852,29 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "aws-sdk": {
+      "version": "2.830.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.830.0.tgz",
+      "integrity": "sha512-vFatoWkdJmRzpymWbqsuwVsAJdhdAvU2JcM9jKRENTNKJw90ljnLyeP1eKCp4O3/4Lg43PVBwY/KUqPy4wL+OA==",
+      "requires": {
+        "buffer": "4.9.2",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
+      }
+    },
     "axe-core": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
@@ -900,6 +923,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
     },
     "binary-extensions": {
       "version": "2.1.0",
@@ -1067,6 +1095,16 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "4.9.2",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+      "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "buffer-equal-constant-time": {
@@ -2015,6 +2053,11 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
       "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "express": {
       "version": "4.17.1",
       "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
@@ -2392,6 +2435,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -2602,6 +2650,11 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/iterall/-/iterall-1.3.0.tgz",
       "integrity": "sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg=="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -3429,6 +3482,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -3647,6 +3705,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "scmp": {
       "version": "2.1.0",
@@ -4333,6 +4396,22 @@
         "punycode": "^2.1.0"
       }
     },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
+    },
     "url-parse": {
       "version": "1.4.7",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.7.tgz",
@@ -4550,6 +4629,22 @@
       "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      },
+      "dependencies": {
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+        }
+      }
     },
     "xmlbuilder": {
       "version": "13.0.2",

--- a/backend/graphql_api/lambda/package.json
+++ b/backend/graphql_api/lambda/package.json
@@ -10,6 +10,7 @@
     "@apollo/client": "^3.2.4",
     "apollo-server": "^2.18.2",
     "apollo-server-lambda": "^2.18.2",
+    "aws-sdk": "^2.830.0",
     "classnames": "^2.2.6",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/backend/graphql_api/lambda/ses/sesClient.js
+++ b/backend/graphql_api/lambda/ses/sesClient.js
@@ -1,0 +1,45 @@
+const AWS = require('aws-sdk');
+const AWS_SES_API_VERSION = '2019-09-27';
+
+module.exports = (logger) => {
+  const module = {};
+
+  module.api = new AWS.SESV2({
+    apiVersion: AWS_SES_API_VERSION,
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    region: process.env.AWS_DEFAULT_REGION,
+  });
+
+  module.sendEmail = (recipientEmailAddress, messageBody) => {
+    logger.info(
+      `Sending email to ${recipientEmailAddress} with subject: ${messageSubject} body: ${messageBody}`
+    );
+
+    if (process.env.SEND_EMAIL != 'true') {
+      logger.warn(`Sending email is disabled. Set SEND_EMAIL=true in .env.`)
+      return
+    }
+
+    let params = {
+      Content: {
+        Simple: {
+          Body: { Text: { Data: messageSubject } },
+          Subject: { Data: messageSubject },
+        },
+      },
+      Destination: { ToAddresses: [recipientEmailAddress] },
+      FromEmailAddress: process.env.FROM_ADDRESS,
+    };
+
+    module.api.sendEmail(params, function (err, _) {
+      if (err) {
+        logger.info(`Email failed to send to ${recipientEmailAddress} due to ${err}.`);
+      } else {
+        logger.info(`Email sent to ${recipientEmailAddress}.`);
+      }
+    });
+  };
+
+  return module;
+};

--- a/backend/graphql_api/lambda/twilio/twilioClient.js
+++ b/backend/graphql_api/lambda/twilio/twilioClient.js
@@ -6,12 +6,31 @@ module.exports = (logger) => {
   const module = {};
 
   module.sendTextMessage = (recipientPhoneNumber, messageBody) => {
+    messageBody += ` To opt out, reply 'STOP' anytime.`
     logger.info(`Sending text message to ${recipientPhoneNumber} with body: ${messageBody}`);
+
+    if (process.env.SEND_TEXT != 'true') {
+      logger.warn(`Sending text is disabled. Set SEND_TEXT=true in .env.`)
+      return
+    }
+
+    // If you send multiple messages at once from a single Twilio sender
+    // (number or Alphanumeric Sender ID), Twilio will queue them up for
+    // delivery. Your messages may experience differing rate limits based on
+    // the sender you are using. For messages from a US or Canada long code
+    // number, the limit is one message segment per second (MPS).
+    // https://www.twilio.com/docs/sms/send-messages#a-note-on-rate-limiting
     client.messages.create({
       body: messageBody,
       from: process.env.TWILIO_PHONE_NUMBER,
       to: `+${recipientPhoneNumber}`,
-    }).then((message) => logger.debug(JSON.stringify(message)));
+    }, function(err, _) {
+      if (err) {
+        logger.info(`Text failed to sent from ${process.env.TWILIO_PHONE_NUMBER} to ${recipientPhoneNumber} due to ${err}.`)
+      } else {
+        logger.info(`Text sent from ${process.env.TWILIO_PHONE_NUMBER} to ${recipientPhoneNumber}.`)
+      }
+    });
   };
 
   return module;


### PR DESCRIPTION
# TODOS:
- [x] Update Readme to include how to setup AWS SES.
- [ ] Update email body with starter template.
- [x] Merge https://github.com/codeforsanjose/gov-agenda-notifier/pull/100 first

### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
Send email in the same flow as SMS when the meeting starts. Closes https://github.com/codeforsanjose/gov-agenda-notifier/issues/97

- Describe what changes are being made
Creates sesClient which sends email through AWS SES.

- Describe how errors will be handled. How will we know if this code breaks in production
Errors due to AWS SES API are logged using `logger`.

- Describe any external libraries/dependencies added or removed in this PR
aws-sdk added.

- Describe any security risks are there regarding this change
None.

- Describe how you tested these changes
Made this change on graphql API frontend and saw email was sent.
```
mutation {
  updateMeeting(
    id: 1,
    status: "IN PROGRESS",
    meeting_start_timestamp: "10",
    meeting_end_timestamp: "10",
    virtual_meeting_url:"https://google.com",
    meeting_type:"test"
  ) {
  	status
  }
}
```

- Link to relevant external documentation
<!--- Add your answer here -->
<!--- Example: API docs, architecture diagrams, MDN docs -->


--------------------------
### :clipboard: Mandatory Checklist
- [ ] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [x] Have you discussed these changes with the project leader(s)?
- [x] Do all variable and function names communicate what they do?
- [x] Were all the changes commented and / or documented?
- [x] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [x] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [x] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->


#### After
<!--- Add after screenshots here -->
![image](https://user-images.githubusercontent.com/164864/105439496-d3a9f200-5c19-11eb-8c60-b19631ec0eff.png)


--------------------------
### :blue_book: Glossary
- PR = Pull Request
