### PR TITLE
add migration for account table

### DIFF
--- a/backend/graphql_api/lambda/migrations/0002-account.sql
+++ b/backend/graphql_api/lambda/migrations/0002-account.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS account (
+  id SERIAL NOT NULL PRIMARY KEY,
+  name VARCHAR(50),
+  unsubscribe_token VARCHAR(50),
+  email_address VARCHAR(50) UNIQUE NOT NULL,
+  phone_number VARCHAR(50),
+  phone_number_subscribed BOOLEAN DEFAULT 'f',
+  email_address_subscribed BOOLEAN DEFAULT 'f',
+  created_timestamp TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  roles VARCHAR(50)[] DEFAULT '{user}'
+);


### PR DESCRIPTION
'user' is a postgres resevered word and I wanted to follow naming convention, hence 'account'