### PR TITLE
rename "account#unsubscribe_token" to "token"

### DIFF
--- a/backend/graphql_api/lambda/db/dbClient.js
+++ b/backend/graphql_api/lambda/db/dbClient.js
@@ -199,8 +199,7 @@ module.exports = async (logger) => {
 
   module.toogleConfirmByToken = async (token, toogleBoolean) => {
     logger.info('dbClient: unconfirmUserByToken');
-    // TODO: change unsubscribe_token column once it's been changed in DB
-    return query(`UPDATE account SET email_address_subscribed = ${toogleBoolean} WHERE unsubscribe_token = '${token}'`);
+    return query(`UPDATE account SET email_address_subscribed = ${toogleBoolean} WHERE token = '${token}'`);
   };
 
   return module;

--- a/backend/graphql_api/lambda/migrations/0004-account-change-to-token.sql
+++ b/backend/graphql_api/lambda/migrations/0004-account-change-to-token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account RENAME COLUMN unsubscribe_token TO token;


### PR DESCRIPTION
Renaming the field since the token is now being used for both confirmation and unsubscribe.