### PR TITLE
Add email confirmation page to allow user to subscribe/unsubscribe

### DIFF
--- a/frontend/src/components/EmailConfirmPage/EmailConfirmPage.jsx
+++ b/frontend/src/components/EmailConfirmPage/EmailConfirmPage.jsx
@@ -4,6 +4,9 @@ import { useMutation } from '@apollo/client';
 
 import { CONFIRM_EMAIL, UNCONFIRM_EMAIL } from '../../graphql/graphql';
 
+// TODO: Add styling and replace placeholder text
+// https://github.com/codeforsanjose/gov-agenda-notifier/issues/146
+
 function EmailConfirmPage() {
   const { token, action } = useParams();
   const validActions = new Set(['subscribe', 'unsubscribe']);

--- a/frontend/src/components/EmailConfirmPage/EmailConfirmPage.jsx
+++ b/frontend/src/components/EmailConfirmPage/EmailConfirmPage.jsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { Redirect, useParams } from 'react-router-dom';
+import { useMutation } from '@apollo/client';
+
+import { CONFIRM_EMAIL, UNCONFIRM_EMAIL } from '../../graphql/graphql';
+
+function EmailConfirmPage() {
+  const { token, action } = useParams();
+  const validActions = new Set(['subscribe', 'unsubscribe']);
+
+  const currentMutation = action === 'subscribe' ? CONFIRM_EMAIL : UNCONFIRM_EMAIL;
+  const [callMutation, { loading, error, data }] = useMutation(currentMutation);
+
+  if (!validActions.has(action)) return <Redirect to="/" />;
+  if (loading) return 'Loading...';
+  if (error) return `An error occured: ${error}`;
+
+  return (
+    <div className="EmailConfirmPage">
+      <p>
+        {
+          action === 'subscribe'
+            ? 'Confirm email subscription'
+            : 'Unsubscribe from email notification'
+        }
+      </p>
+
+      <button
+        type="submit"
+        onClick={() => callMutation(token)}
+      >
+        {
+          action === 'subscribe'
+            ? 'Confirm Email'
+            : 'Unsubscribe'
+        }
+      </button>
+
+      {/* DEBUG */}
+      <div style={{width: '600px', margin: '20px auto', backgroundColor: '#eee', color: '#361515', padding: '10px 20px', border: '1px solid #aaa'}}>
+        <p>{`Action: ${action}`}</p>
+        <p>{`Token: ${token}`}</p>
+        <p>Data:</p>
+        <div><pre>{JSON.stringify(data, null, 2)}</pre></div>
+      </div>
+      {/* END DEBUG */}
+    </div>
+  );
+}
+
+export default EmailConfirmPage;

--- a/frontend/src/components/EmailConfirmPage/EmailConfirmPage.jsx
+++ b/frontend/src/components/EmailConfirmPage/EmailConfirmPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Redirect, useParams } from 'react-router-dom';
 import { useMutation } from '@apollo/client';
 
@@ -14,7 +14,15 @@ function EmailConfirmPage() {
   const currentMutation = action === 'subscribe' ? CONFIRM_EMAIL : UNCONFIRM_EMAIL;
   const [callMutation, { loading, error, data }] = useMutation(currentMutation);
 
+  useEffect(() => {
+    if (data) {
+      // TODO: perform an action after successful mutation
+    }
+  }, [data]);
+
   if (!validActions.has(action)) return <Redirect to="/" />;
+
+  // TODO: add loading and error handling
   if (loading) return 'Loading...';
   if (error) return `An error occured: ${error}`;
 

--- a/frontend/src/graphql/graphql.js
+++ b/frontend/src/graphql/graphql.js
@@ -38,3 +38,19 @@ export const CREATE_SUBSCRIPTIONS = gql`
     }
   }
 `;
+
+export const CONFIRM_EMAIL = gql`
+  mutation confirmEmail(
+    $token: String
+  ) {
+    confirmEmail(token: $token)
+  }
+`;
+
+export const UNCONFIRM_EMAIL = gql`
+  mutation unconfirmEmail(
+    $token: String
+  ) {
+    unconfirmEmail(token: $token)
+  }
+`;

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -23,6 +23,7 @@ import MeetingView from './components/MeetingView/MeetingView';
 import Subscribe from './components/Subscribe/Subscribe';
 import AdminView from './components/AdminView/AdminView';
 import AdminUploadView from './components/AdminView/AdminUploadView/AdminUploadView';
+import EmailConfirmPage from './components/EmailConfirmPage/EmailConfirmPage';
 import Footer from './components/Footer/Footer';
 
 import * as serviceWorker from './serviceWorker';
@@ -81,6 +82,9 @@ function App() {
               </Route>
               <Route path="/meeting/:id">
                 <MeetingView />
+              </Route>
+              <Route path="/confirm/:token/:action">
+                <EmailConfirmPage />
               </Route>
 
               {/* <Route exact path="/participate/join">


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
New feature

- Describe what changes are being made
A new route `/confirm/:token/:action` is created for the new `EmailConfirmPage`. This is the page users are sent to after clicking on the link that they receive in their email. Currently a placeholder page with no styling/copy but can be used to test the `confirmEmail` and `unconfirmEmail` mutations on the back end.

- Describe why these changes are being made
Resolves #135 

- List the use cases and edge cases relevant to this PR
<!--- Add your answer here -->

- Describe how errors will be handled. How will we know if this code breaks in production
<!--- Add your answer here -->

- Describe any external libraries/dependencies added or removed in this PR
<!--- Add your answer here -->

- Describe any security risks are there regarding this change
<!--- Add your answer here -->

- Describe how you tested these changes
Added debug messages to confirm proper response from gql after using mutation

- Link to relevant external documentation
<!--- Add your answer here -->
<!--- Example: API docs, architecture diagrams, MDN docs -->


--------------------------
### :clipboard: Mandatory Checklist
- [ ] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [ ] Have you discussed these changes with the project leader(s)?
- [ ] Do all variable and function names communicate what they do?
- [ ] Were all the changes commented and / or documented?
- [ ] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [ ] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [ ] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->


#### After
<!--- Add after screenshots here -->


--------------------------
### :blue_book: Glossary
- PR = Pull Request
