### PR TITLE
Show checkbox only when status is pending. Issue #180

### DIFF
--- a/frontend/src/components/MeetingView/AgendaView/AgendaItem.jsx
+++ b/frontend/src/components/MeetingView/AgendaView/AgendaItem.jsx
@@ -120,7 +120,7 @@ const RenderedAgendaItem = forwardRef(({
           && <div className="item-status">{item.status}</div>}
 
       <div className="row">
-        <input type="checkbox" checked={isSelected} onChange={handleCheck} />
+        {item.status === MeetingItemStates.PENDING && <input type="checkbox" checked={isSelected} onChange={handleCheck} />}
         <h4>{item.title_loc_key}</h4>
       </div>
       <p>{item.description_loc_key}</p>


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
One-line change to show checkbox only when status is pending

- Describe what changes are being made
Added a simple comparison to a line so that it only renders the checkbox when the status is pending.

- Describe why these changes are being made
Issue #180

- List the use cases and edge cases relevant to this PR


- Describe how errors will be handled. How will we know if this code breaks in production


- Describe any external libraries/dependencies added or removed in this PR


- Describe any security risks are there regarding this change


- Describe how you tested these changes
Used three different groups with three different status to ensure that only the pending status had the checkbox visible. Also checked and unchecked  the boxes to make sure they continued to function correctly.

- Link to relevant external documentation



--------------------------
### :clipboard: Mandatory Checklist

- [x] Example of a checked item (please remove when creating your Pull Request) 

- [x] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [ ] Have you discussed these changes with the project leader(s)?
- [x] Do all variable and function names communicate what they do?
- [x] Were all the changes commented and / or documented?
- [x] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [ ] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [x] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->
![before](https://user-images.githubusercontent.com/32974267/114947225-93fe3b00-9e01-11eb-821c-fe15da938844.png)




#### After
<!--- Add after screenshots here -->
![after](https://user-images.githubusercontent.com/32974267/114947210-8fd21d80-9e01-11eb-8f68-368bb089e77d.png)



--------------------------
### :blue_book: Glossary
- PR = Pull Request
