### PR TITLE
Frontend Deploy changes

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:14 as builder
 
+ARG REACT_APP_GRAPHQL_URL
+
 WORKDIR /app
 
 COPY package*.json /app/

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -2,9 +2,12 @@ server {
     listen       80;
     server_name  localhost;
 
+
+    root /usr/local/openresty/nginx/html;
+    index index.html;
+
     location / {
-        root   /usr/local/openresty/nginx/html;
-        index  index.html index.htm;
+      try_files $uri $uri.html $uri/ /index.html;
     }
 
     error_page   500 502 503 504  /50x.html;

--- a/frontend/nginx/default.conf
+++ b/frontend/nginx/default.conf
@@ -2,6 +2,12 @@ server {
     listen       80;
     server_name  localhost;
 
+    location /graphql {
+      set_by_lua_block $prod_api_url { return os.getenv("PROD_API_URL"),":",os.getenv("PROD_API_PORT")}
+
+      resolver 8.8.8.8;
+      proxy_pass http://${prod_api_url};
+    }
 
     root /usr/local/openresty/nginx/html;
     index index.html;
@@ -10,8 +16,10 @@ server {
       try_files $uri $uri.html $uri/ /index.html;
     }
 
+
     error_page   500 502 503 504  /50x.html;
     location = /50x.html {
         root   /usr/local/openresty/nginx/html;
     }
+
 }

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -4,6 +4,10 @@ events {
     worker_connections  1024;
 }
 
+
+env PROD_API_URL;
+env PROD_API_PORT;
+
 http {
     include       mime.types;
     default_type  application/octet-stream;

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -33,7 +33,7 @@ import AdminPaths from './constants/AdminPaths';
 import './i18n';
 
 const client = new ApolloClient({
-  uri: `${process.env.REACT_APP_GRAPHQL_URL}`,
+  uri: `${process.env.REACT_APP_GRAPHQL_URL}/graphql`,
   cache: new InMemoryCache(),
 });
 

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -33,7 +33,7 @@ import AdminPaths from './constants/AdminPaths';
 import './i18n';
 
 const client = new ApolloClient({
-  uri: `http://${process.env.REACT_APP_GRAPHQL_URL}/graphql`,
+  uri: `${process.env.REACT_APP_GRAPHQL_URL}/graphql`,
   cache: new InMemoryCache(),
 });
 

--- a/frontend/src/index.jsx
+++ b/frontend/src/index.jsx
@@ -33,7 +33,7 @@ import AdminPaths from './constants/AdminPaths';
 import './i18n';
 
 const client = new ApolloClient({
-  uri: `${process.env.REACT_APP_GRAPHQL_URL}/graphql`,
+  uri: `${process.env.REACT_APP_GRAPHQL_URL}`,
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
Fixing URL interpolation for REACT_APP_GRAPHQL_URL so that it we can manipulate http vs https.
This is because production API is listening on https