### PR TITLE
GraphQL API: Add deleteMeeting mutation

### DIFF
--- a/backend/graphql_api/lambda/db/dbClient.js
+++ b/backend/graphql_api/lambda/db/dbClient.js
@@ -88,6 +88,12 @@ module.exports = async (logger) => {
     return query(queryString, [id]);
   };
 
+  module.deleteMeeting = async (id) => {
+    logger.info('dbClient: deleteMeeting');
+    const queryString = 'DELETE FROM meeting WHERE id = $1';
+    return query(queryString, [id]);
+  };
+
   module.createMeetingItem = async (meetingId, orderNumber, itemStartTimestamp, itemEndTimestamp,
     status, contentCategories, descriptionLocKey, titleLocKey, parentMeetingItemId) => {
     logger.info('dbClient: createMeetingItem');

--- a/backend/graphql_api/lambda/graphql/apolloServer.js
+++ b/backend/graphql_api/lambda/graphql/apolloServer.js
@@ -49,6 +49,8 @@ module.exports = (logger) => {
 
         createAccount(first_name: String, last_name: String, email_address: String, password: String): auth_data
 
+        deleteMeeting(id: Int!): String
+
         # TODO: Need to add update user info mutation
     }
 
@@ -205,6 +207,10 @@ module.exports = (logger) => {
       updateMeeting: async (_parent, args, context) => {
         logger.info('Initiating UpdateMeeting Mutation resolver');
         return resolverHandler(mutationResolver.updateMeeting, args, context);
+      },
+      deleteMeeting: async (_parent, args, context) => {
+        logger.info('Initiating DeleteMeeting Mutation resolver');
+        return resolverHandler(mutationResolver.deleteMeeting, args, context);
       },
       createMeetingItem: async (_parent, args, context) => {
         logger.info('Initiating CreateMeetingItem Mutation resolver');

--- a/backend/graphql_api/lambda/graphql/resolvers/mutation.js
+++ b/backend/graphql_api/lambda/graphql/resolvers/mutation.js
@@ -223,6 +223,19 @@ module.exports = (logger) => {
     return res.rows[0];
   };
 
+  module.deleteMeeting = async (dbClient, args, context) => {
+    validator.validateAuthorization(context);
+
+    let res;
+    try {
+      res = await dbClient.deleteMeeting(args.id);
+    } catch (e) {
+      logger.error(`deleteMeeting resolver error - dbClient.deleteMeeting: ${e}`);
+      throw e;
+    }
+    return res;
+  };
+
   module.createAccount = async (dbClient, args, context) => {
     let res;
     let user;

--- a/backend/graphql_api/lambda/migrations/0008-meeting-fk-on-delete-cascade.sql
+++ b/backend/graphql_api/lambda/migrations/0008-meeting-fk-on-delete-cascade.sql
@@ -1,0 +1,6 @@
+ALTER TABLE meeting
+DROP CONSTRAINT fk_meeting_id,
+ADD CONSTRAINT fk_meeting_id
+FOREIGN KEY (meeting_id)
+REFERENCES meeting(id)
+ON DELETE CASCADE


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
Adds deleteMeeting mutation to the GraphQL API.

- Describe what changes are being made
Closes #207. Adds new deleteMeeting mutation defined in `apolloServer.js`, which calls new deleteMeeting mutation defined in `mutation.js`, which calls new deleteMeeting mutation defined in `dbClient.js`.

- Describe why these changes are being made
For the client to be able to delete a meeting by ID.

- List the use cases and edge cases relevant to this PR
If the meeting doesn't exist, it should still return gracefully.

- Describe how errors will be handled. How will we know if this code breaks in production
<!--- Add your answer here -->

- Describe any external libraries/dependencies added or removed in this PR
<!--- Add your answer here -->

- Describe any security risks are there regarding this change
Anyone could theoretically delete meetings. Should there be a system of delete permissions?

- Describe how you tested these changes
<!--- Add your answer here -->

- Link to relevant external documentation
<!--- Add your answer here -->
<!--- Example: API docs, architecture diagrams, MDN docs -->


--------------------------
### :clipboard: Mandatory Checklist

- [x] Example of a checked item (please remove when creating your Pull Request) 

- [ ] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [ ] Have you discussed these changes with the project leader(s)?
- [ ] Do all variable and function names communicate what they do?
- [ ] Were all the changes commented and / or documented?
- [ ] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [ ] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [ ] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->


#### After
<!--- Add after screenshots here -->


--------------------------
### :blue_book: Glossary
- PR = Pull Request
