### PR TITLE
Fix the update status button for content uploaded as csv

### DIFF
--- a/backend/agenda_upload_service/lambda/controllers/uploadController.js
+++ b/backend/agenda_upload_service/lambda/controllers/uploadController.js
@@ -66,7 +66,7 @@ module.exports = (logger) => {
       // eslint-disable-next-line no-await-in-loop
       const res = await dbClient.createMeetingItem(
         meetingId, null, orderNumber, null, null,
-        'PENDING', '[content, categories]', 'description', amendedTitle,
+        'PENDING', 'test', 'description', amendedTitle,
       );
       const rootMeetingItemId = res.rows[0].id;
       orderNumber += 1;
@@ -82,7 +82,7 @@ module.exports = (logger) => {
         // eslint-disable-next-line no-await-in-loop
         const res = await dbClient.createMeetingItem(
           meetingId, rootMeetingItemId, orderNumber, null, null,
-          'PENDING', '[content, categories]', 'description', amendedTitle,
+          'PENDING', 'test', 'description', amendedTitle,
         );
         orderNumber += 1;
       }

--- a/backend/graphql_api/lambda/graphql/resolvers/validators.js
+++ b/backend/graphql_api/lambda/graphql/resolvers/validators.js
@@ -51,15 +51,17 @@ module.exports = (logger) => {
   const isNumericString = (string) => /^\d+$/.test(string);
 
   const validateTimestamp = (ts, fieldName, context) => {
-    const tsIsNumeric = isNumericString(ts);
-    if (!tsIsNumeric) {
-      const msg = `Invalid "${fieldName}" field. Timestamp is not numeric: ${ts}`;
-      throwUserInputError(msg, context);
-    }
-    const isValidDate = new Date(parseInt(ts, 10)).getTime() > 0;
-    if (!isValidDate) {
-      const msg = `Invalid "${fieldName}" field. Timestamp is not a valid date: ${ts}`;
-      throwUserInputError(msg, context);
+    if(ts != '0'){
+      const tsIsNumeric = isNumericString(ts);
+      if (!tsIsNumeric) {
+        const msg = `Invalid "${fieldName}" field. Timestamp is not numeric: ${ts}`;
+        throwUserInputError(msg, context);
+      }
+      const isValidDate = new Date(parseInt(ts, 10)).getTime() > 0;
+      if (!isValidDate) {
+        const msg = `Invalid "${fieldName}" field. Timestamp is not a valid date: ${ts}`;
+        throwUserInputError(msg, context);
+      }
     }
   };
 


### PR DESCRIPTION
### :scroll: Description

- Describe the general shape of this PR (new feature? refactor? bug fix? one-line change?)
Fixes the the problem where content uploaded thru a csv file could not be reordered as the update status button caused a error.
For issue #277 

- Describe what changes are being made
Agenda upload now sets category as 'test' which passes the validator.
timestamp validator now allows '0' to pass as an unassigned value

- Describe why these changes are being made
Fix the update status functionality

- List the use cases and edge cases relevant to this PR
<!--- Add your answer here -->

- Describe how errors will be handled. How will we know if this code breaks in production
<!--- Add your answer here -->

- Describe any external libraries/dependencies added or removed in this PR
<!--- Add your answer here -->

- Describe any security risks are there regarding this change
<!--- Add your answer here -->

- Describe how you tested these changes
Created a meeting, uploaded the csv, and saved re-ordered agendaItems.

- Link to relevant external documentation
<!--- Add your answer here -->
<!--- Example: API docs, architecture diagrams, MDN docs -->


--------------------------
### :clipboard: Mandatory Checklist

- [x] Example of a checked item (please remove when creating your Pull Request) 

- [X ] Linked to the Github Issues being addressed using the right sidebar :arrow_right:
- [ ] Have you discussed these changes with the project leader(s)?
- [ ] Do all variable and function names communicate what they do?
- [ ] Were all the changes commented and / or documented?
- [ ] Is the PR the right size? (If the PR is too large to review, it might be good to break it up into multiple PRs.)
- [ ] Does all work in progress, temporary, or debugger code have a TODO comment with links to Github issues?
- [ ] *If you changed the user interface, did you add before and after screenshots to below?*

--------------------------
### :framed_picture: Screenshots and Screen Recordings

#### Before
<!--- Add before screenshots here -->


#### After
<!--- Add after screenshots here -->


--------------------------
### :blue_book: Glossary
- PR = Pull Request
